### PR TITLE
Changing the way timers work

### DIFF
--- a/src/socketio.app.src
+++ b/src/socketio.app.src
@@ -10,5 +10,7 @@
 		  misultin
                  ]},
   {mod, { socketio_app, []}},
-  {env, [ {heartbeat_interval, 10000}, {close_timeout, 8000} ]}
+  {env, [{heartbeat_interval, 10000},
+         {close_timeout, 8000},
+         {polling_duration, 20000}]}
  ]}.

--- a/src/socketio_transport_htmlfile.erl
+++ b/src/socketio_transport_htmlfile.erl
@@ -63,9 +63,9 @@ init([Sup, SessionId, ServerModule, {'htmlfile', {Req, Caller}}]) ->
         _ ->
             error_logger:warning_report(
                 "Could not load default heartbeat_interval value from "
-                "the application file. Setting the default value to infinity."
+                "the application file. Setting the default value to 10000."
             ),
-            infinity
+            10000
     end,
     CloseTimeout = 
     case application:get_env(close_timeout) of
@@ -85,7 +85,7 @@ init([Sup, SessionId, ServerModule, {'htmlfile', {Req, Caller}}]) ->
        req = Req,
        caller = Caller,
        close_timeout = CloseTimeout,
-       heartbeat_interval = HeartbeatInterval,
+       heartbeat_interval = {make_ref(), HeartbeatInterval},
        event_manager = EventMgr,
        sup = Sup
       }}.
@@ -105,21 +105,24 @@ init([Sup, SessionId, ServerModule, {'htmlfile', {Req, Caller}}]) ->
 %% @end
 %%--------------------------------------------------------------------
 %% Incoming data
-handle_call({'htmlfile', data, Req}, _From, #state{ heartbeat_interval = Interval, 
+handle_call({'htmlfile', data, Req}, _From, #state{ heartbeat_interval = Interval,
                                                     server_module = ServerModule,
                                                     event_manager = EventManager } = State) ->
-    Data = apply(ServerModule, parse_post, [Req]),
-    Self = self(),
-    lists:foreach(fun({"data", M}) ->
-        spawn(fun () ->
-            F = fun(#heartbeat{}) -> ignore;
-                   (M0) -> gen_event:notify(EventManager, {message, Self,  M0})
-            end,
-            [F(Msg) || Msg <- socketio_data:decode(#msg{content=M})]
-        end)
-    end, Data),
-    apply(ServerModule, respond, [Req, 200, [{"Content-Type","text/plain"}],"ok"]),
-    {reply, ok, State, Interval};
+    Msgs = [socketio_data:decode(#msg{content=Data}) || {"data", Data} <- ServerModule:parse_post(Req)],
+    F = fun(#heartbeat{}, _Acc) ->
+            {timer, reset_heartbeat(Interval)};
+        (M, Acc) ->
+            gen_event:notify(EventManager, {message, self(), M}),
+            Acc
+    end,
+    NewState = case lists:foldl(F, undefined, lists:flatten(Msgs)) of
+        {timer, NewInterval} ->
+            State#state{ heartbeat_interval = NewInterval};
+        undefined ->
+            State
+    end,
+    ServerModule:respond(Req, 200, [{"Content-Type", "text/plain"}], "ok"),
+    {reply, ok, NewState};
 
 %% Event management
 handle_call(event_manager, _From, #state{ event_manager = EventMgr } = State) ->
@@ -149,26 +152,29 @@ handle_call(stop, _From, State) ->
 %% @end
 %%--------------------------------------------------------------------
 handle_cast({initialize, Req}, #state{ heartbeat_interval = Interval, server_module = ServerModule } = State) ->
-    apply(ServerModule, headers, [Req, [{"Content-Type", "text/html"},
-                                        {"Connection", "Keep-Alive"},
-                                        {"Transfer-Encoding", "chunked"}]]),
-    H = "<html><body>" ++ lists:duplicate(254,$\s),
-    link(apply(ServerModule, socket, [Req])),
-    apply(ServerModule, chunk, [Req, H]),
-    {noreply, State#state{ connection_reference = {'htmlfile', connected} }, Interval};
+    ServerModule:headers(Req, [{"Content-Type", "text/html"},
+                               {"Connection", "Keep-Alive"},
+                               {"Transfer-Encoding", "chunked"}]),
+    H = "<html><body>" ++ lists:duplicate(254, $\s),
+    link(ServerModule:socket(Req)),
+    ServerModule:chunk(Req, H),
+    {noreply, State#state{ connection_reference = {htmlfile, connected},
+                           heartbeat_interval = reset_heartbeat(Interval) }};
 
 handle_cast(heartbeat, #state{ heartbeats = Beats,
                                heartbeat_interval = Interval } = State) ->
     Beats1 = Beats + 1,
     socketio_client:send(self(), #heartbeat{ index = Beats1 }),
-    {noreply, State#state { heartbeats = Beats1 }, Interval};
+    {noreply, State#state{ heartbeats = Beats1,
+                           heartbeat_interval = reset_heartbeat(Interval) }};
 
 %% Send
 handle_cast({send, Message}, #state{ req = Req, 
                                      server_module = ServerModule,
-                                     connection_reference = {'htmlfile', connected }, heartbeat_interval = Interval } = State) ->
+                                     connection_reference = {'htmlfile', connected },
+                                     heartbeat_interval = Interval } = State) ->
     send_message(Message, ServerModule, Req),
-    {noreply, State, Interval};
+    {noreply, State#state{ heartbeat_interval = reset_heartbeat(Interval) }};
 
 handle_cast(_, #state{} = State) ->
     {noreply, State}.
@@ -189,10 +195,10 @@ handle_info({'EXIT',_Port,_Reason}, #state{ close_timeout = ServerTimeout} = Sta
 
 handle_info(timeout, #state{ server_module = ServerModule,
                              connection_reference = {'htmlfile', none}, caller = Caller, req = Req } = State) ->
-    gen_server:reply(Caller, apply(ServerModule, respond, [Req, 200])),
+    gen_server:reply(Caller, ServerModule:respond(Req, 200)),
     {stop, shutdown, State};
 
-handle_info(timeout, State) ->
+handle_info({timeout, _Ref, heartbeat}, State) ->
     gen_server:cast(self(), heartbeat),
     {noreply, State};
 
@@ -237,3 +243,8 @@ send_message(Message, ServerModule, Req) ->
     Message0 =  binary_to_list(jsx:term_to_json(list_to_binary(Message), [{strict, false}])),
     M = "<script>parent.s._(" ++ Message0 ++ ", document);</script>",
     apply(ServerModule, chunk, [Req, M]).
+
+reset_heartbeat({TimerRef, Time}) ->
+    erlang:cancel_timer(TimerRef),
+    NewRef = erlang:start_timer(Time, self(), heartbeat),
+    {NewRef, Time}.

--- a/src/socketio_transport_htmlfile.erl
+++ b/src/socketio_transport_htmlfile.erl
@@ -190,14 +190,33 @@ handle_cast(_, #state{} = State) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
+%% CLient disconnected. We fire a timer (ServerTimeout)!
 handle_info({'EXIT',_Port,_Reason}, #state{ close_timeout = ServerTimeout} = State) when is_port(_Port) ->
     {noreply, State#state { connection_reference = {'htmlfile', none}}, ServerTimeout};
 
+%% This branch handles two purposes: 1. handling the close_timeout,
+%% 2. handling the heartbeat timeout that might comes first. The thing is,
+%% when the client connection dies, we need to wait for the close_timeout
+%% to be fired. That one can be cancelled at any time by God knows what for now,
+%% and that might be desirable. However, it can also be cancelled because we
+%% happen to receive the heartbeat timeout. Given the right setting, this will
+%% happen every time a disconnection happens at the point where the delay left to
+%% the current heartbeat is longer than the delay left to the total value of
+%% close_timout. Funny, eh?
+%% For this reason, the heartbeat timeout when we have no htmlfile
+%% connection reference has to be seen as the same as the close_timeout
+%% timer firing off. This is the safest way to guarantee everything will run
+%% okay.
 handle_info(timeout, #state{ server_module = ServerModule,
                              connection_reference = {'htmlfile', none}, caller = Caller, req = Req } = State) ->
     gen_server:reply(Caller, ServerModule:respond(Req, 200)),
     {stop, shutdown, State};
 
+%% See previous clauses' comments
+handle_info({timeout, _Ref, heartbeat}, #state{ connection_reference = {'htmlfile', none} } = State) ->
+    handle_info(timeout, State);
+
+%% Regular heartbeat
 handle_info({timeout, _Ref, heartbeat}, State) ->
     gen_server:cast(self(), heartbeat),
     {noreply, State};

--- a/src/socketio_transport_polling.erl
+++ b/src/socketio_transport_polling.erl
@@ -62,7 +62,7 @@ init([Sup, SessionId, ServerModule, {TransportType, {Req, Index}}]) ->
             Time;
         _ ->
             error_logger:warning_report(
-                "Could not load default heartbeat_interval value from "
+                "Could not load default polling_duration value from "
                 "the application file. Setting the default value to 20000 ms."
             ),
             20000

--- a/src/socketio_transport_polling.erl
+++ b/src/socketio_transport_polling.erl
@@ -82,7 +82,7 @@ init([Sup, SessionId, ServerModule, {TransportType, {Req, Index}}]) ->
        connection_reference = {TransportType, none},
        req = Req,
        index = Index,
-       polling_duration = PollingDuration,
+       polling_duration = {make_ref(), PollingDuration},
        close_timeout = CloseTimeout,
        event_manager = EventMgr,
        sup = Sup
@@ -108,26 +108,32 @@ init([Sup, SessionId, ServerModule, {TransportType, Req}]) ->
 %%--------------------------------------------------------------------
 %% Incoming data
 handle_call({_TransportType, data, Req}, From, #state{ server_module = ServerModule,
-                                                       event_manager = EventManager, sup = Sup } = State) ->
-    Data = apply(ServerModule, parse_post, [Req]),
-    Self = self(),
-    Response =
-	case cors_headers(apply(ServerModule, get_headers, [Req]), Sup) of
-	    {false, _Headers} ->
-            gen_server:reply(From, apply(ServerModule, respond, [Req, 405, "unauthorized"]));
-	    {_, Headers0} ->
-		Self = self(),
-    		lists:foreach(fun({"data", M}) ->
-    				      spawn(fun () ->
-    						    F = fun(#heartbeat{}) -> ignore;
-    							   (M0) -> gen_event:notify(EventManager, {message, Self,  M0})
-    							end,
-     							[F(Msg) || Msg <- socketio_data:decode(#msg{content=M})]
-    					    end)
-    			      end, Data),
-		gen_server:reply(From, apply(ServerModule, respond,[Req, 200, [Headers0|[{"Content-Type", "text/plain"}]], "ok"]))
-	end,
-    {reply, Response, State};
+                                                       event_manager = EventManager,
+                                                       polling_duration = Interval,
+                                                       sup = Sup } = State) ->
+    Msgs = [socketio_data:decode(#msg{content=Data}) || {"data", Data} <- ServerModule:parse_post(Req)],
+    {Response, NewState} =
+    case cors_headers(ServerModule:get_headers(Req), Sup) of
+        {false, _Headers} ->
+            Reply = gen_server:reply(From, ServerModule:respond(Req, 405, "unauthorized")),
+            {Reply, State};
+        {_, Headers} ->
+            F = fun(#heartbeat{}, _Acc) ->
+                    {timer, reset_duration(Interval)};
+                (M, Acc) ->
+                    gen_event:notify(EventManager, {message, self(), M}),
+                    Acc
+            end,
+            TmpState = case lists:foldl(F, undefined, lists:flatten(Msgs)) of
+                {timer, NewInterval} ->
+                    State#state{ polling_duration = NewInterval};
+                undefined ->
+                    State
+            end,
+            Reply = gen_server:reply(From, ServerModule:respond(Req, 200, [Headers | [{"Content-Type", "text/plain"}]], "ok")),
+            {Reply, TmpState}
+    end,
+    {reply, Response, NewState};
 
 %% Event management
 handle_call(event_manager, _From, #state{ event_manager = EventMgr } = State) ->
@@ -160,10 +166,13 @@ handle_call(stop, _From, State) ->
 handle_cast({TransportType, polling_request, {Req, Index}, Server}, State) ->
     handle_cast({TransportType, polling_request, Req, Server}, State#state{ index = Index});
 handle_cast({TransportType, polling_request, Req, Server}, #state { server_module = ServerModule,
-                                                                    polling_duration = Interval, message_buffer = [] } = State) ->
-    apply(ServerModule, ensure_longpolling_request, [Req]),
-    link(apply(ServerModule, socket, [Req])),
-    {noreply, State#state{ connection_reference = {TransportType, connected}, req = Req, caller = Server }, Interval};
+                                                                    polling_duration = Interval,
+                                                                    message_buffer = [] } = State) ->
+    ServerModule:ensure_longpolling_request(Req),
+    link(ServerModule:socket(Req)),
+    {noreply, State#state{ connection_reference = {TransportType, connected}, req = Req,
+                           caller = Server,
+                           polling_duration = reset_duration(Interval) }};
 
 handle_cast({TransportType, polling_request, Req, Server}, #state { server_module = ServerModule, 
                                                                     message_buffer = Buffer } = State) ->
@@ -179,7 +188,8 @@ handle_cast({send, Message}, #state{ server_module = ServerModule,
                                      connection_reference = {TransportType, connected }, req = Req, caller = Caller,
                                      index = Index, sup = Sup, polling_duration = Interval} = State) ->
     gen_server:reply(Caller, send_message(Message, Req, Index, ServerModule, Sup)),
-    {noreply, State#state{ connection_reference = {TransportType, none}}, Interval};
+    {noreply, State#state{ connection_reference = {TransportType, none},
+                           polling_duration = reset_duration(Interval) }};
 
 handle_cast(_, State) ->
     {noreply, State}.
@@ -199,7 +209,7 @@ handle_info({'EXIT',Port,_Reason}, #state{ connection_reference = {TransportType
     {noreply, State#state { connection_reference = {TransportType, none}}, CloseTimeout};
 
 %% Connection has timed out
-handle_info(timeout, #state{ server_module = ServerModule, 
+handle_info({timeout, _Ref, polling}, #state{ server_module = ServerModule,
                              connection_reference = {_TransportType, connected},
                              caller = Caller, req = Req, index = Index, sup = Sup } = State) ->
     gen_server:reply(Caller, send_message("", Req, Index, ServerModule, Sup)),
@@ -301,3 +311,8 @@ cors_headers(Headers, Sup) ->
 		    {false, Headers}
 	    end
     end.
+
+reset_duration({TimerRef, Time}) ->
+    erlang:cancel_timer(TimerRef),
+    NewRef = erlang:start_timer(Time, self(), polling),
+    {NewRef, Time}.

--- a/src/socketio_transport_xhr_multipart.erl
+++ b/src/socketio_transport_xhr_multipart.erl
@@ -63,9 +63,9 @@ init([Sup, SessionId, ServerModule, {'xhr-multipart', {Req, Caller}}]) ->
         _ ->
             error_logger:warning_report(
                 "Could not load default heartbeat_interval value from "
-                "the application file. Setting the default value to infinity."
+                "the application file. Setting the default value to 10000."
             ),
-            infinity
+            10000
     end,
     CloseTimeout = 
     case application:get_env(close_timeout) of
@@ -89,7 +89,7 @@ init([Sup, SessionId, ServerModule, {'xhr-multipart', {Req, Caller}}]) ->
        req = Req,
        caller = Caller,
        close_timeout = CloseTimeout,
-       heartbeat_interval = HeartbeatInterval,
+       heartbeat_interval = {make_ref(), HeartbeatInterval},
        event_manager = EventMgr,
        sup = Sup
       }}.
@@ -110,19 +110,23 @@ init([Sup, SessionId, ServerModule, {'xhr-multipart', {Req, Caller}}]) ->
 %%--------------------------------------------------------------------
 %% Incoming data
 handle_call({'xhr-multipart', data, Req}, _From, #state{ server_module = ServerModule,
-                                                         heartbeat_interval = Interval, event_manager = EventManager } = State) ->
-    Data = apply(ServerModule, parse_post, [Req]),
-    Self = self(),
-    lists:foreach(fun({"data", M}) ->
-        spawn(fun () ->
-            F = fun(#heartbeat{}) -> ignore;
-                   (M0) -> gen_event:notify(EventManager, {message, Self,  M0})
-            end,
-            [F(Msg) || Msg <- socketio_data:decode(#msg{content=M})]
-        end)
-    end, Data),
-    apply(ServerModule, respond, [Req, 200,[{"Content-Type","text/plain"}],"ok"]),
-    {reply, ok, State, Interval};
+                                                         heartbeat_interval = Interval,
+                                                         event_manager = EventManager } = State) ->
+    Msgs = [socketio_data:decode(#msg{content=Data}) || {"data", Data} <- ServerModule:parse_post(Req)],
+    F = fun(#heartbeat{}, _Acc) ->
+            {timer, reset_heartbeat(Interval)};
+        (M, Acc) ->
+            gen_event:notify(EventManager, {message, self(), M}),
+            Acc
+    end,
+    NewState = case lists:foldl(F, undefined, lists:flatten(Msgs)) of
+        {timer, NewInterval} ->
+            State#state{ heartbeat_interval = NewInterval};
+        undefined ->
+            State
+    end,
+    ServerModule:respond(Req, 200, [{"Content-Type", "text/plain"}], "ok"),
+    {reply, ok, NewState};
 
 %% Event management
 handle_call(event_manager, _From, #state{ event_manager = EventMgr } = State) ->
@@ -152,8 +156,8 @@ handle_call(stop, _From, State) ->
 %% @end
 %%--------------------------------------------------------------------
 handle_cast({initialize, Req}, #state{ server_module = ServerModule, heartbeat_interval = Interval } = State) ->
-    Headers = apply(ServerModule, get_headers, [Req]),
-    Headers1 = 
+    Headers = ServerModule:get_headers(Req),
+    Headers1 =
     case proplists:get_value('Origin', Headers) of
         undefined ->
             Headers;
@@ -161,29 +165,32 @@ handle_cast({initialize, Req}, #state{ server_module = ServerModule, heartbeat_i
             case socketio_listener:verify_origin(Origin, socketio_listener:origins(listener(State))) of
                 true ->
                     [{"Access-Control-Allow-Origin", "*"},
-                     {"Access-Control-Allow-Credentials", "true"}|Headers];
+                     {"Access-Control-Allow-Credentials", "true"} | Headers];
                 false ->
                     Headers
             end
     end,
-    link(apply(ServerModule, socket, [Req])),
-    apply(ServerModule, headers, [Req,  [{"Content-Type", "multipart/x-mixed-replace;boundary=\"socketio\""},
-                                             {"Connection", "Keep-Alive"}|Headers1]]),
-    apply(ServerModule, stream, [Req, "--socketio\n"]),
-    {noreply, State#state{ connection_reference = {'xhr-multipart', connected} }, Interval};
+    link(ServerModule:socket(Req)),
+    ServerModule:headers(Req, [{"Content-Type", "multipart/x-mixed-replace;boundary=\"socketio\""},
+                               {"Connection", "Keep-Alive"} | Headers1]),
+    ServerModule:stream(Req, "--socketio\n"),
+    {noreply, State#state{ connection_reference = {'xhr-multipart', connected},
+                           heartbeat_interval = reset_heartbeat(Interval) }};
 
 handle_cast(heartbeat, #state{ heartbeats = Beats,
                                heartbeat_interval = Interval } = State) ->
     Beats1 = Beats + 1,
     socketio_client:send(self(), #heartbeat{ index = Beats1 }),
-    {noreply, State#state { heartbeats = Beats1 }, Interval};
+    {noreply, State#state { heartbeats = Beats1,
+                            heartbeat_interval = reset_heartbeat(Interval) }};
 
 %% Send
 handle_cast({send, Message}, #state{ req = Req, 
                                      server_module = ServerModule,
-                                     connection_reference = {'xhr-multipart', connected }, heartbeat_interval = Interval } = State) ->
+                                     connection_reference = {'xhr-multipart', connected },
+                                     heartbeat_interval = Interval } = State) ->
     send_message(Message, Req, ServerModule),
-    {noreply, State, Interval};
+    {noreply, State#state{ heartbeat_interval = reset_heartbeat(Interval) }};
 
 handle_cast(_, #state{} = State) ->
     {noreply, State}.
@@ -204,10 +211,10 @@ handle_info({'EXIT',_Port,_Reason}, #state{ close_timeout = ServerTimeout} = Sta
 
 handle_info(timeout, #state{ server_module = ServerModule,
                              connection_reference = {'xhr-multipart', none}, req = Req, caller = Caller } = State) ->
-    gen_server:reply(Caller, apply(ServerModule, respond, [Req, 200, ""])),
+    gen_server:reply(Caller, ServerModule:respond(Req, 200, "")),
     {stop, shutdown, State};
 
-handle_info(timeout, State) ->
+handle_info({timeout, _Ref, heartbeat}, State) ->
     gen_server:cast(self(), heartbeat),
     {noreply, State};
 
@@ -255,3 +262,8 @@ send_message(Message, Req, ServerModule) ->
 
 listener(#state{ sup = Sup }) ->
     socketio_listener:server(Sup).
+
+reset_heartbeat({TimerRef, Time}) ->
+    erlang:cancel_timer(TimerRef),
+    NewRef = erlang:start_timer(Time, self(), heartbeat),
+    {NewRef, Time}.


### PR DESCRIPTION
I'm opening this as a pull request so we can discuss whatever happens in my fork for this one.

Following OJ's problems, I've rewritten all our heartbeat timeouts and polling limits to be based on the erlang timer BIFs rather than the 'Timeout' value returned in a gen_server tuple. This should generally be safer considering any standard call to the transport process (including to get the event manager and whatnot) would reset the timer and cause heartbeats to be missed on the server-side, prompting the client to reconnect for no reason.

I've also added a few default values (changed from infinity to 10s, to be in sync with the websocket transport), removed a few useless processes spawn (was necessary for the timers anyway), and changed many apply/3 calls with a known arity to a Mod:Fun(Args) format, which should be faster.

We still need people to check that I didn't break anything with the timers too, and note that the close_timeouts used by the polling transports weren't changed because I have no idea what should cancel them in term of events.
