### PR TITLE
Stable jsx version

### DIFF
--- a/src/socketio.app.src
+++ b/src/socketio.app.src
@@ -3,7 +3,7 @@
   {description, ""},
   {vsn, "1"},
   {registered, []},
-  {agner, [{requires, ["misultin", "ossp_uuid","jsx","proper","ex_uri"]}]},
+  {agner, [{requires, ["misultin", "ossp_uuid",{"jsx","0.9.0"},"proper","ex_uri"]}]},
   {applications, [
                   kernel,
                   stdlib,

--- a/test/prop_transport.erl
+++ b/test/prop_transport.erl
@@ -91,7 +91,7 @@ heartbeat() -> ?LET(N, int(), abs(N)).
 json() ->
     ?LET(Compiled,
          ?LET(X, [json_data(),end_json], lists:flatten(X)),
-         jsx:json_to_term(jsx:format(eventify(Compiled)))).
+         jsx:json_to_term(jsx:format(jsx:eventify(Compiled)))).
 
 json_data() ->
     ?LAZY(weighted_union([
@@ -116,15 +116,3 @@ val() ->
 
 ascii() ->
     list(choose($a,$z)).
-
-
-eventify([]) ->
-    fun() -> 
-	    {incomplete, fun(List) when is_list(List) -> 
-				 eventify(List);
-			    (_) ->
-				 erlang:error(badarg) 
-			 end}
-    end;    
-eventify([Next|Rest]) ->
-    fun() -> {event, Next, eventify(Rest)} end. 


### PR DESCRIPTION
This branch fixes the jsx version to 0.9.0 to avoid
the currently changing API of the app.
