### PR TITLE
Allowing multiple handlers through a hack

### DIFF
--- a/demo/demo.erl
+++ b/demo/demo.erl
@@ -1,5 +1,5 @@
 #! /usr/bin/env escript
-%%! -pa ../ebin ../deps/misultin/ebin ../deps/ossp_uuid/ebin ../deps/jsx/ebin 
+%%! -pa ../ebin ../deps/misultin/ebin ../deps/ossp_uuid/ebin ../deps/jsx/ebin ../deps/gproc/ebin/
 -mode(compile).
 -include_lib("../include/socketio.hrl").
 -compile(export_all).
@@ -12,6 +12,7 @@
 main(_) ->
     appmon:start(),
     application:start(sasl),
+    application:start(gproc),
     application:start(misultin),
     application:start(socketio),
     {ok, Pid} = socketio_listener:start([{http_port, 7878}, 

--- a/demo/demo.erl
+++ b/demo/demo.erl
@@ -18,6 +18,9 @@ main(_) ->
                                          {default_http_handler,?MODULE}]),
     {ok, Pid} = socketio_listener:start([{http_port, 7878}, 
                                          {default_http_handler,?MODULE}]),
+    {ok, Pid2} = socketio_listener:start([{http_port, 7879}, 
+                                          {default_http_handler,?MODULE}]),
+    true = Pid2 =/= Pid,
     EventMgr = socketio_listener:event_manager(Pid),
     ok = gen_event:add_handler(EventMgr, ?MODULE,[]),
     receive _ -> ok end.

--- a/demo/demo_ssl.erl
+++ b/demo/demo_ssl.erl
@@ -1,5 +1,5 @@
 #! /usr/bin/env escript
-%%! -pa ../ebin ../deps/misultin/ebin ../deps/ossp_uuid/ebin ../deps/jsx/ebin 
+%%! -pa ../ebin ../deps/misultin/ebin ../deps/ossp_uuid/ebin ../deps/jsx/ebin ../deps/gproc/ebin
 -mode(compile).
 -include_lib("../include/socketio.hrl").
 -compile(export_all).
@@ -12,6 +12,7 @@
 main(_) ->
     appmon:start(),
     application:start(sasl),
+    application:start(gproc),
     application:start(misultin),
     application:start(socketio),
     {ok, Pid} = socketio_listener:start([{http_port, 7878}, 

--- a/src/socketio.app.src
+++ b/src/socketio.app.src
@@ -1,13 +1,14 @@
 {application, socketio,
  [
   {description, ""},
-  {vsn, "1"},
+  {vsn, "1.1"},
   {registered, []},
-  {agner, [{requires, ["misultin", "ossp_uuid",{"jsx","0.9.0"},"proper","ex_uri"]}]},
+  {agner, [{requires, ["misultin", "ossp_uuid",{"jsx","0.9.0"},"proper","ex_uri", "gproc"]}]},
   {applications, [
                   kernel,
                   stdlib,
-		  misultin
+                  gproc,
+                  misultin
                  ]},
   {mod, { socketio_app, []}},
   {env, [{heartbeat_interval, 10000},

--- a/src/socketio_client.erl
+++ b/src/socketio_client.erl
@@ -20,9 +20,7 @@ start_link(Sup, Module, SessionId, ServerModule, ConnectionReference) ->
     Module:start_link(Sup, SessionId, ServerModule, ConnectionReference).
 
 start(Sup0, Module, SessionId, ServerModule, ConnectionReference, Port) ->
-    Children = supervisor:which_children(Sup0),
-    Name = list_to_atom(atom_to_list(socketio_client_sup) ++ "_" ++ integer_to_list(Port)),
-    {Sup, _, _, _} = lists:keyfind(Name ,1, Children),
+    Sup = gproc:lookup_local_name({socketio_client_sup, Port}),
     supervisor:start_child(Sup, [Sup0, Module, SessionId, ServerModule, ConnectionReference]).
 
 

--- a/src/socketio_client.erl
+++ b/src/socketio_client.erl
@@ -2,7 +2,7 @@
 -include_lib("socketio.hrl").
 
 %% API
--export([start_link/5, start/5]).
+-export([start_link/5, start/6]).
 -export([event_manager/1, send/2, session_id/1, request/1]).
 
 %%%===================================================================
@@ -19,9 +19,10 @@
 start_link(Sup, Module, SessionId, ServerModule, ConnectionReference) ->
     Module:start_link(Sup, SessionId, ServerModule, ConnectionReference).
 
-start(Sup0, Module, SessionId, ServerModule, ConnectionReference) ->
+start(Sup0, Module, SessionId, ServerModule, ConnectionReference, Port) ->
     Children = supervisor:which_children(Sup0),
-    {Sup, _, _, _} = lists:keyfind(socketio_client_sup,1, Children),
+    Name = list_to_atom(atom_to_list(socketio_client_sup) ++ "_" ++ integer_to_list(Port)),
+    {Sup, _, _, _} = lists:keyfind(Name ,1, Children),
     supervisor:start_child(Sup, [Sup0, Module, SessionId, ServerModule, ConnectionReference]).
 
 

--- a/src/socketio_client_sup.erl
+++ b/src/socketio_client_sup.erl
@@ -16,14 +16,14 @@
 %% ===================================================================
 
 start_link(Port) ->
-    Name = list_to_atom(atom_to_list(?MODULE)++"_"++integer_to_list(Port)),
-    supervisor:start_link({local, Name}, ?MODULE, []).
+    supervisor:start_link(?MODULE, [Port]).
 
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
-init([]) ->
+init([Port]) ->
+    gproc:add_local_name({?MODULE, Port}),
     {ok, { {simple_one_for_one, 5, 10}, [
                                   {socketio_client, {socketio_client, start_link, []}, 
                                    transient, 5000, worker, [socketio_client]}

--- a/src/socketio_client_sup.erl
+++ b/src/socketio_client_sup.erl
@@ -3,7 +3,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([start_link/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -15,8 +15,9 @@
 %% API functions
 %% ===================================================================
 
-start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+start_link(Port) ->
+    Name = list_to_atom(atom_to_list(?MODULE)++"_"++integer_to_list(Port)),
+    supervisor:start_link({local, Name}, ?MODULE, []).
 
 %% ===================================================================
 %% Supervisor callbacks

--- a/src/socketio_http.erl
+++ b/src/socketio_http.erl
@@ -18,7 +18,8 @@
           sup,
           web_server_monitor,
           server_module,
-          resource
+          resource,
+          port  % very dirty hack
          }).
 
 %%%===================================================================
@@ -64,7 +65,8 @@ init([ServerModule, Port, Resource, SSL, DefaultHttpHandler, Sup]) ->
        sup = Sup,
        web_server_monitor = WebServerRef,
        server_module = ServerModule,
-       resource = Resource
+       resource = Resource,
+       port = Port
       }}.
 
 %%--------------------------------------------------------------------
@@ -206,10 +208,11 @@ handle_call({session, generate, ConnectionReference, Transport}, _From, #state{
                                                                    sup = Sup,
                                                                    sessions = Sessions,
                                                                    event_manager = EventManager,
-                                                                   server_module = ServerModule
+                                                                   server_module = ServerModule,
+                                                                   port = Port
                                                                   } = State) ->
     UUID = binary_to_list(ossp_uuid:make(v4, text)),
-    {ok, Pid} = socketio_client:start(Sup, Transport, UUID, ServerModule, ConnectionReference),
+    {ok, Pid} = socketio_client:start(Sup, Transport, UUID, ServerModule, ConnectionReference, Port),
     link(Pid),
     ets:insert(Sessions, [{UUID, Pid}, {Pid, UUID}]),
     gen_event:notify(EventManager, {client, Pid}),

--- a/src/socketio_listener_sup.erl
+++ b/src/socketio_listener_sup.erl
@@ -16,7 +16,10 @@
 %% ===================================================================
 
 start_link(Options) ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, [Options]).
+    %% This is a terrible, sad hack to avoid duplicates
+    Port = proplists:get_value(http_port, Options),
+    Name = list_to_atom(atom_to_list(?MODULE)++"_"++integer_to_list(Port)),
+    supervisor:start_link({local, Name}, ?MODULE, [Options]).
 
 %% ===================================================================
 %% Supervisor callbacks
@@ -44,7 +47,7 @@ init([Options]) ->
                                                                                self()]}, 
                                    permanent, 5000, worker, [socketio_http]},
 
-                                  {socketio_client_sup, {socketio_client_sup, start_link, []}, 
+                                  {list_to_atom("socketio_client_sup_" ++ integer_to_list(HttpPort)), {socketio_client_sup, start_link, [HttpPort]}, 
                                    permanent, infinity, supervisor, [socketio_client_sup]}
 
                                  ]} }.


### PR DESCRIPTION
This is done by using dynamic atoms (a bad thing) based on
the number of ports you have a connection on.

A good design would have required a substantial rewrite of
the application. However, to simply get things working in
a decent way, although not perfect in terms of patterns,
I decided to go this way. It is worth the time for an
application in maintenance -- no technical debt on this
one, unless someone else wants to take control.
